### PR TITLE
Log debit and credit transactions during fund transfer

### DIFF
--- a/src/main/java/com/example/ewallet/services/TransactionServiceImpl.java
+++ b/src/main/java/com/example/ewallet/services/TransactionServiceImpl.java
@@ -115,13 +115,27 @@ public class TransactionServiceImpl implements TransactionService{
         walletRepository.save(fromWallet);
         walletRepository.save(toWallet);
 
-        // Log the transaction
-        Transaction transaction = new Transaction();
-        transaction.setFromWallet(fromWallet);
-        transaction.setToWallet(toWallet);
-        transaction.setAmount(transferDTO.getAmount());
-        transaction.setDescription("Funds Transfer");
-        transactionRepository.save(transaction);
+        // Log the transaction for the sender (debit)
+        Transaction debitTransaction = new Transaction();
+        debitTransaction.setWallet(fromWallet);
+        debitTransaction.setFromWallet(fromWallet);
+        debitTransaction.setToWallet(toWallet);
+        debitTransaction.setAmount(transferDTO.getAmount());
+        debitTransaction.setType(Transaction.TransactionType.DEBIT);
+        debitTransaction.setStatus(Transaction.TransactionStatus.SUCCESS);
+        debitTransaction.setDescription("Funds Transfer");
+        transactionRepository.save(debitTransaction);
+
+        // Log the transaction for the receiver (credit)
+        Transaction creditTransaction = new Transaction();
+        creditTransaction.setWallet(toWallet);
+        creditTransaction.setFromWallet(fromWallet);
+        creditTransaction.setToWallet(toWallet);
+        creditTransaction.setAmount(transferDTO.getAmount());
+        creditTransaction.setType(Transaction.TransactionType.CREDIT);
+        creditTransaction.setStatus(Transaction.TransactionStatus.SUCCESS);
+        creditTransaction.setDescription("Funds Transfer");
+        transactionRepository.save(creditTransaction);
     }
 
     @Override

--- a/src/test/java/com/example/ewallet/services/TransactionServiceImplTest.java
+++ b/src/test/java/com/example/ewallet/services/TransactionServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.example.ewallet.services;
+
+import com.example.ewallet.dto.TransferDTO;
+import com.example.ewallet.entities.Transaction;
+import com.example.ewallet.entities.Wallet;
+import com.example.ewallet.repositories.AccountRepository;
+import com.example.ewallet.repositories.TransactionRepository;
+import com.example.ewallet.repositories.WalletRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TransactionServiceImplTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private WalletRepository walletRepository;
+    @Mock
+    private AccountRepository accountRepository;
+
+    @InjectMocks
+    private TransactionServiceImpl transactionService;
+
+    private Wallet fromWallet;
+    private Wallet toWallet;
+
+    @BeforeEach
+    void setUp() {
+        fromWallet = new Wallet();
+        fromWallet.setId(1L);
+        fromWallet.setBalance(100.0);
+
+        toWallet = new Wallet();
+        toWallet.setId(2L);
+        toWallet.setBalance(50.0);
+    }
+
+    @Test
+    void transferFundsCreatesDebitAndCreditTransactions() {
+        when(walletRepository.findById(1L)).thenReturn(Optional.of(fromWallet));
+        when(walletRepository.findById(2L)).thenReturn(Optional.of(toWallet));
+
+        TransferDTO dto = new TransferDTO();
+        dto.setFromWallet(1L);
+        dto.setToWallet(2L);
+        dto.setAmount(30.0);
+
+        transactionService.transferFunds(dto);
+
+        assertEquals(70.0, fromWallet.getBalance());
+        assertEquals(80.0, toWallet.getBalance());
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(transactionRepository, times(2)).save(captor.capture());
+        List<Transaction> savedTransactions = captor.getAllValues();
+
+        Transaction debit = savedTransactions.get(0);
+        assertEquals(Transaction.TransactionType.DEBIT, debit.getType());
+        assertEquals(Transaction.TransactionStatus.SUCCESS, debit.getStatus());
+        assertEquals(fromWallet, debit.getWallet());
+
+        Transaction credit = savedTransactions.get(1);
+        assertEquals(Transaction.TransactionType.CREDIT, credit.getType());
+        assertEquals(Transaction.TransactionStatus.SUCCESS, credit.getStatus());
+        assertEquals(toWallet, credit.getWallet());
+    }
+}


### PR DESCRIPTION
## Summary
- Record separate debit and credit entries when transferring funds
- Add unit test for fund transfer transaction logging

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_b_689533a9b8f883219d8856733d70cf75