### PR TITLE
Fix Docker base image and compose warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY src ./src
 RUN mvn -q package -DskipTests
 
 # Runtime stage
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   backend:
     build: .


### PR DESCRIPTION
## Summary
- use cross-platform Temurin JRE base image
- remove obsolete version field from docker-compose

## Testing
- `mvn -q package -DskipTests` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `docker build -t backend-test .` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68953a1f4e708321a83b0d1e26997095